### PR TITLE
PR: Adding Nav-Bar Hamburger Toggle Menu Styling for Mobile View

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@supabase/supabase-js": "^2.49.8",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-icons": "^5.5.0",
         "react-scroll": "^1.9.3"
       },
       "devDependencies": {
@@ -2989,6 +2990,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@supabase/supabase-js": "^2.49.8",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-icons": "^5.5.0",
     "react-scroll": "^1.9.3"
   },
   "devDependencies": {

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-scroll";
+import { FaBars } from "react-icons/fa";
 import "../styles/navbar.css";
 
 const Navbar = () => {
@@ -56,6 +57,11 @@ const Navbar = () => {
       <div className="navbar-phone-btn">
         <div className="default-text">Contact Us</div>
         <div className="hover-text">011-456-7890</div>
+      </div>
+
+      {/* Hamburger Menu - visible only on mobile */}
+      <div className="navbar-toggle">
+        <FaBars size={24} />
       </div>
     </nav>
   );

--- a/src/styles/navbar.css
+++ b/src/styles/navbar.css
@@ -46,3 +46,25 @@
 .navbar-phone-btn:hover .default-text {
   opacity: 0;
 }
+
+/* Hide Hamburger by default */
+.navbar-toggle {
+  display: none;
+}
+
+/* Mobile Styles */
+@media (max-width: 768px) {
+  .navbar {
+    padding: 1rem;
+  }
+
+  .navbar-links,
+  .navbar-phone-btn {
+    display: none;
+  }
+
+  .navbar-toggle {
+    display: block;
+    cursor: pointer;
+  }
+}


### PR DESCRIPTION
This PR implements:
- Applies CSS media queries to target max-width: 768px for mobile view.

On mobile:
- Displays only the branding ("Lupus Together") and a hamburger menu icon.
- Hides the nav links and the “Contact Us” button.

On desktop:
- Maintains the full nav bar layout with all links and the contact button visible.
- Adds a placeholder hamburger icon using react-icons (no interactivity yet).